### PR TITLE
Added the Code Climate binary to the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter \
-    && chmod +x /usr/bin/cc-test-reporter
+    && chmod +x /usr/local/bin/cc-test-reporter
 
 RUN \
 	go get -u github.com/rubenv/sql-migrate/...

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN \
 	pip install --upgrade pip && \
 	pip install awscli --upgrade && \
 	apk --purge -v del py-pip && \
-	rm /var/cache/apk/*
+	rm -Rf /var/cache/apk/*
 
 ENV DOCKERIZE_VERSION v0.6.1
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,8 @@ RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSI
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter \
+    && chmod +x /usr/bin/cc-test-reporter
+
 RUN \
 	go get -u github.com/rubenv/sql-migrate/...


### PR DESCRIPTION
Currently, the Code Climate binary is downloaded and installed at build time. This should speed the builds up slightly and will simplify the build scripts for Go projects.